### PR TITLE
ci: adopt sovereign-ci.yml reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,96 +1,21 @@
-# Unified CI — self-hosted clean-room runners for sovereignty (§2.1.1)
-# Spec: docs/specifications/unified-ci-pipeline.md
-#
-# Calls the centralized reusable gate workflow in paiml/.github.
-# Branch protection requires "unified / gate" to pass before merge.
-
+# Sovereign CI — calls reusable workflow from paiml/.github
+# Change once in paiml/.github → applies to all repos
 name: CI
 
 on:
-  pull_request_target:
-    branches: [main, master]
   push:
     branches: [main, master]
-  workflow_dispatch:  # manual trigger for testing
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
 
-# One CI run per branch/PR; cancel stale runs on same branch
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  unified:
-    uses: paiml/.github/.github/workflows/unified-gate.yml@main
+  ci:
+    uses: paiml/.github/.github/workflows/sovereign-ci.yml@main
     with:
       repo: ${{ github.event.repository.name }}
-      pr_sha: ${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit
-
-  test:
-    runs-on: [self-hosted, clean-room]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - run: cargo test --lib
-
-  coverage:
-    runs-on: [self-hosted, clean-room]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-cov-${{ hashFiles('**/Cargo.lock') }}
-      - run: cargo install cargo-llvm-cov --locked || true
-      - run: cargo llvm-cov test --lib --lcov --output-path lcov.info
-      - uses: codecov/codecov-action@v4
-        with:
-          files: lcov.info
-        continue-on-error: true
-
-  lint:
-    runs-on: [self-hosted, clean-room]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
-      - run: cargo clippy -- -D warnings
-
-  security:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo install cargo-audit --locked || true
-      - run: cargo audit
-
-  gate:
-    name: gate
-    runs-on: [self-hosted, clean-room]
-    if: always()
-    needs: [test, lint, coverage, security]
-    steps:
-      - name: Check all jobs
-        run: |
-          if [ "${{ needs.test.result }}" = "failure" ] || [ "${{ needs.lint.result }}" = "failure" ]; then
-            exit 1
-          fi


### PR DESCRIPTION
Replaces per-repo CI with single reusable workflow. Badge reflects only test/lint/coverage/security.