### PR TITLE
ci(nextest): enable use_nextest pilot (PMAT-155 Phase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,13 @@ jobs:
     uses: paiml/.github/.github/workflows/sovereign-ci.yml@main
     with:
       repo: ${{ github.event.repository.name }}
+      # PMAT-155 Phase 2 nextest pilot (build-performance.md §4.3 + §7 Phase 2).
+      # pzsh = healthy ~387-test --lib suite; the `test` job is green on main
+      # (the pre-existing `security` advisory failure is orthogonal to this pilot
+      # and to the F11 test-job metric). cargo-nextest is baked into
+      # sovereign-ci:stable (infra Dockerfile). Pilot only — keep until F11
+      # test-job p95 ≤ 300s is verified over 7 days, then promote fleet-wide.
+      use_nextest: true
     secrets: inherit
 
   # Top-level gate: satisfies org ruleset which requires check named "gate".


### PR DESCRIPTION
## PMAT-155 Phase 2 — nextest migration pilot

Enables `use_nextest: true` on the shared `sovereign-ci` reusable workflow call for **pzsh** (one of 3 pilot repos).

### Why pzsh
- Healthy ~387-test `--lib` suite — a good signal source for the F11 test-job p95 metric.
- The `ci / test` job is **green on main**. The pre-existing `ci / security` cargo-audit advisory failure is orthogonal to this pilot and does not affect the nextest-driven test job or its F11 measurement.
- `cargo-nextest` is already baked into `sovereign-ci:stable` (infra `machines/intel/sovereign-ci/Dockerfile`, `cargo install cargo-nextest --locked`, verified at image build via `cargo nextest --version`).
- The reusable workflow falls back to `cargo test` if nextest fails, so this is low-risk.

### What this does
The `test` job runs `cargo nextest run` instead of `cargo test` (build-performance.md §4.3). Expected 30-40% test-job speedup on larger suites.

### Pilot scope
This is a **pilot only**. Keep `use_nextest: true` here until **F11 test-job p95 ≤ 300s is verified over a 7-day observation window** (build-performance.md §7 Phase 2), then promote fleet-wide. The 7-day observation is a separate WAIT step that cannot be completed at PR-open time.

Refs PMAT-155

🤖 Generated with [Claude Code](https://claude.com/claude-code)