### PR TITLE
chore(release): pzsh 0.3.6 — green maintenance refresh + verified provable contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "pzsh"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 exclude = ["tests/", "benches/", "docs/", ".github/", "book/", ".pmat/"]
 name = "pzsh"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 authors = ["paiml"]
 description = "Performance-first shell framework with sub-10ms startup"


### PR DESCRIPTION
## Release prep: pzsh 0.3.5 -> 0.3.6

Maintenance refresh to a crates.io-ready version. `0.3.5` is already published; this PR bumps to `0.3.6` and verifies the full green gate. **Do not publish from this PR** — clean-room + `cargo publish` are driven separately.

### Build + test
- `cargo build` — green
- `cargo test` — 387 lib + 14 integration tests pass, 0 failures
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo deny check advisories` — `advisories ok` (3 stale `advisory-not-detected` warnings only, no live vulns)

### Quality
- `pmat tdg .` — **91.7/100 (A-)** overall; per-file all A- (29 files, avg 95.3), no F/D-grade files
- `pmat quality-gate` — clean except one degenerate `entropy` violation (`repetitions: 0, saves 0 lines`) which is a known spurious metric, not a structural blocker
- 0 complexity / SATD / dead-code violations

### Provable contracts
The crate already has a foundational contract covering its core invariant (the hard 10ms startup bound):
- `provable-contracts/contracts/pzsh/shell-execution-v1.yaml` — `pv validate` → **0 errors, valid**
- Equations: `startup_budget` (T(init) <= 10ms hard limit), `parser_correctness`, `config_validation`
- 3 proof_obligations, 4 falsification_tests (FALSIFY-PZS-001..004), 3 kani_harnesses (KANI-PZS-001..003), qa_gate `F-PZS-001`
- Wired via `binding.yaml` (3 implemented bindings) → `src/generated_contracts.rs` (build.rs codegen, debug_assert! at zero release cost)

No new contract needed — the existing one already models the crate's real core invariants.

### Version
- `0.3.5` -> `0.3.6` (patch; maintenance refresh) in `Cargo.toml` + `Cargo.lock`
- Confirmed `0.3.6` is NOT yet on crates.io (latest published: 0.3.5)
- No CHANGELOG file in repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)